### PR TITLE
Change wording around compiler suggestion

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Head to our [test runners guide](docs/test-runners.md) to learn more about how t
 
 ## Compiling your contracts
 
-`test-environment` is not a contract compiler: for that, you'll want to use the [OpenZeppelin CLI](https://docs.openzeppelin.com/sdk/2.5/).
+`test-environment` is not a contract compiler. You can use the [OpenZeppelin CLI](https://docs.openzeppelin.com/sdk) to compile just as easily.
 
 ```bash
 npm install --save-dev @openzeppelin/cli

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Head to our [test runners guide](docs/test-runners.md) to learn more about how t
 
 ## Compiling your contracts
 
-`test-environment` is not a contract compiler. You can use the [OpenZeppelin CLI](https://docs.openzeppelin.com/sdk) to compile just as easily.
+`test-environment` is not a contract compiler. You can use the [OpenZeppelin CLI](https://docs.openzeppelin.com/sdk) to compile your Solidity files just as easily.
 
 ```bash
 npm install --save-dev @openzeppelin/cli


### PR DESCRIPTION
The current wording seems to suggest that it's not possible to use other compilers. 

Also, note that you can remove the version number from any docs link and it will redirect to the latest one, which right now is 2.6.