### PR TITLE
Fix usage with --inspect flag

### DIFF
--- a/src/setup-ganache.ts
+++ b/src/setup-ganache.ts
@@ -29,6 +29,9 @@ export type Options = {
 
 export default async function(): Promise<string> {
   const server = fork(path.join(__dirname, 'ganache-server'), [], {
+    // Prevent the child process from also being started in inspect mode, which
+    // would cause issues due to parent and child sharing the port.
+    // See https://github.com/OpenZeppelin/openzeppelin-test-environment/pull/23
     execArgv: process.execArgv.filter(opt => opt !== '--inspect')
   });
 

--- a/src/setup-ganache.ts
+++ b/src/setup-ganache.ts
@@ -28,7 +28,9 @@ export type Options = {
 };
 
 export default async function(): Promise<string> {
-  const server = fork(path.join(__dirname, 'ganache-server'), [], { execArgv: [] });
+  const server = fork(path.join(__dirname, 'ganache-server'), [], {
+    execArgv: process.execArgv.filter(opt => opt !== '--inspect')
+  });
 
   const options: Options = {
     accountsConfig,

--- a/src/setup-ganache.ts
+++ b/src/setup-ganache.ts
@@ -28,7 +28,7 @@ export type Options = {
 };
 
 export default async function(): Promise<string> {
-  const server = fork(path.join(__dirname, 'ganache-server'));
+  const server = fork(path.join(__dirname, 'ganache-server'), [], { execArgv: [] });
 
   const options: Options = {
     accountsConfig,


### PR DESCRIPTION
Mocha has poor error reporting for crashes that happen before tests start running. For those situations, the recommended debugging method is to use the `--inspect` flag, which is a [Node feature](https://nodejs.org/en/docs/guides/debugging-getting-started/).

Currently, when using `--inspect` along with `test-environment`, the following happens:
 * the debugging server is started and correctly reports errors
 * the ganache server fails to load (all calls to it timeout)
 * the following message is logged: `Starting inspector on 127.0.0.1:9229 failed: address already in use`

What is going on here is a bit tricky. `--inspect` creates a server in port 9229, so no two processes may run with that flag at the same time. However, as has been noted [on the Node repo](https://github.com/nodejs/node/issues/14325), this is precisely what happens with `.fork` is used. This is because `fork` [forwards `execArgv` by default](https://nodejs.org/api/child_process.html#child_process_child_process_fork_modulepath_args_options), passing the child process the same options the parent one received (`process.execArgv`).

From the [Node docs](https://node.readthedocs.io/en/latest/api/process/#processexecargv):

>process.execArgv
>This is the set of node-specific command line options from the executable that started the process. These options do not show up in process.argv, and do not include the node executable, the name of the script, or any options following the script name. These options are useful in order to spawn child processes with the same execution environment as the parent.

To preserve this intended behaviour, this PR simply prevents the `--inspect` flag from being forwarded.