### PR TITLE
Add note on --exit

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,8 @@ Don't forget to make Mocha the entry point of your test suite once you install i
 }
 ```
 
+_Note: the `--exit` flag is required when using truffle contracts. Otherwise, the test suite will not exit._
+
 It is now time to modify the test files themselves. The changes are few, but important:
  1. Add `require('@openzeppelin/test-environment')` to access the variables exported by the library: `accounts`, `contract`, `web3`, etc.
  1. `truffle test` automagically imports Chai: you will need to `require` it and set it up manually


### PR DESCRIPTION
The `--exit` flag is easily missed, and forgetting to include it can lead to frustration. I wanted to highlight its inclusion.

For reference, what `--exit` does is force Mocha to quit after tests complete. This means that the process will exit even if there are pending promises, timers, or if the event loop is otherwise not empty. Instances of `@truffle/contract` register an event listener for 25 transaction confirmations, which will not ever happen for the last tests because no new blocks are being mined. [It is not possible yet to configure the contracts to not do this](https://github.com/trufflesuite/truffle/issues/2560), so we must resort to forcefully quit.

If `@truffle/contract` is not being used (e.g. if `contracts.type` is `web3` on the configuration), then `--exit` shouldn't be used, as it is helpful in detecting bugs in the test suite.