### PR TITLE
Publish types for TypeScript users

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openzeppelin/test-environment",
-  "version": "0.1.2",
+  "version": "0.1.1",
   "description": "One-line setup for an awesome testing experience.",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openzeppelin/test-environment",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "One-line setup for an awesome testing experience.",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.1",
   "description": "One-line setup for an awesome testing experience.",
   "main": "./lib/index.js",
+  "types": "./lib/index.d.ts",
   "scripts": {
     "compile": "rm -rf lib && tsc",
     "docs": "oz-docs -c docs",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
   "files": [
     "lib",
     "!*.test.js",
-    "!*.test.js.map"
+    "!*.test.js.map",
+    "!*.test.d.ts"
   ],
   "husky": {
     "hooks": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,11 +3,4 @@ import { web3, provider } from './setup-provider';
 import { accounts, defaultSender } from './accounts';
 import contract from './setup-loader';
 
-module.exports = {
-  accounts,
-  defaultSender,
-  web3,
-  provider,
-  contract,
-  isHelpersConfigured,
-};
+export { accounts, defaultSender, web3, provider, contract, isHelpersConfigured };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "code-style/tsconfig.json",
   "compilerOptions": {
+    "declaration": true,
     "outDir": "./lib",
   },
   "include": ["./src"]


### PR DESCRIPTION
When trying to use test-environment in TypeScript, there's no exported types. I made a couple of minimal changes, so that TypeScript users importing this library can immediately start using it.