### PR TITLE
Add link to contract loader

### DIFF
--- a/docs/modules/ROOT/pages/api.adoc
+++ b/docs/modules/ROOT/pages/api.adoc
@@ -53,7 +53,10 @@ contract.fromArtifact: (contract: string) => any;
 contract.fromABI: (abi: object, bytecode?: string | undefined) => any;
 ----
 
-The `contract` object is in charge of creating contracts from compilation artifacts. It does this via two functions: * `fromArtifact` looks for a `.json` file in the `build/contracts` directory (equivalent to Truffle's `artifact.require`) * `fromABI` receives an ABI object directly, useful when the full compilation artifacts are not available
+The `contract` object is in charge of creating contracts from compilation artifacts. It does this via two functions:
+
+* `fromArtifact` looks for a `.json` file in the local or a dependency's `build/contracts` directory (equivalent to Truffle's `artifact.require`).
+* `fromABI` receives an ABI object directly, useful when the full compilation artifacts are not available.
 
 They both return instances of either https://www.npmjs.com/package/@truffle/contract[`@truffle/contract`] (by default) or https://web3js.readthedocs.io/en/v1.2.0/web3-eth-contract.html[`web3-eth-contract`], depending on your xref:getting-started.adoc#configuration[configuration].
 

--- a/docs/modules/ROOT/pages/api.adoc
+++ b/docs/modules/ROOT/pages/api.adoc
@@ -67,6 +67,8 @@ const ERC20 = contract.fromArtifact('ERC20');
 const myToken = await ERC20.new(initialBalance, initialHolder);
 ----
 
+NOTE: Head over to the xref:contract-loader::index.adoc[documentation for Contract Loader] to learn more.
+
 == web3
 
 A https://www.npmjs.com/package/web3[`web3`] instance, connected to the local testing blockchain. Useful to access utiltiies like `web3.eth.sign`, `web3.eth.getTransaction`, or `web3.utils.sha3`.


### PR DESCRIPTION
The new link doesn't work in the preview because the referenced component doesn't exist there, but I've tried it locally and it works fine.