### PR TITLE
expose generated private keys

### DIFF
--- a/src/accounts.test.ts
+++ b/src/accounts.test.ts
@@ -1,4 +1,5 @@
 import Web3 from 'web3';
+import { privateToAddress, toChecksumAddress } from 'ethereumjs-util';
 
 import { generateAccounts } from './accounts';
 
@@ -9,7 +10,14 @@ describe('generateAccounts function', (): void => {
     const config = generateAccounts(accountsNumber, balance);
 
     expect(config.accounts.length).toBe(accountsNumber);
+    expect(config.privateKeys.length).toBe(accountsNumber);
     expect(config.accountsConfig.length).toBe(accountsNumber);
+
+    config.privateKeys.forEach((privateKey, index) => {
+      const address = privateToAddress(Buffer.from(privateKey.replace(/0x/, ''), 'hex'));
+      const checksumAddress = toChecksumAddress(address.toString('hex'));
+      expect(checksumAddress).toBe(config.accounts[index]);
+    });
 
     for (const account of config.accountsConfig) {
       expect(account.balance).toBe(Web3.utils.toWei(balance.toString(), 'ether'));

--- a/src/accounts.ts
+++ b/src/accounts.ts
@@ -19,10 +19,11 @@ function generateAccounts(count: number, ether: number) {
   const wallets = Array.from({ length: count }, wallet.generate);
   const accounts = wallets.map(w => w.getChecksumAddressString());
   const accountsConfig = wallets.map(getConfig(ether));
-  return { accounts, accountsConfig };
+  const privateKeys = accountsConfig.map(c => c.secretKey);
+  return { accounts, privateKeys, accountsConfig };
 }
 
-const { accounts: allAccounts, accountsConfig } = generateAccounts(
+const { accounts: allAccounts, privateKeys: allPrivateKeys, accountsConfig } = generateAccounts(
   config.accounts.amount + 1, // extra account for the default sender
   config.accounts.ether,
 );
@@ -36,5 +37,6 @@ const { accounts: allAccounts, accountsConfig } = generateAccounts(
 
 const defaultSender = allAccounts[0];
 const accounts = allAccounts.slice(1);
+const privateKeys = allPrivateKeys.slice(1);
 
-export { accounts, accountsConfig, defaultSender, getConfig, generateAccounts };
+export { accounts, privateKeys, accountsConfig, defaultSender, getConfig, generateAccounts };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import isHelpersConfigured from './helpers';
 import { web3, provider } from './setup-provider';
-import { accounts, defaultSender } from './accounts';
+import { accounts, privateKeys, defaultSender } from './accounts';
 import contract from './setup-loader';
 
-export { accounts, defaultSender, web3, provider, contract, isHelpersConfigured };
+export { accounts, privateKeys, defaultSender, web3, provider, contract, isHelpersConfigured };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import isHelpersConfigured from './helpers';
 import { web3, provider } from './setup-provider';
-import { accounts, accountsConfig, defaultSender } from './accounts';
+import { accounts, defaultSender } from './accounts';
 import contract from './setup-loader';
 
-export { accounts, accountsConfig, defaultSender, web3, provider, contract, isHelpersConfigured };
+export { accounts, defaultSender, web3, provider, contract, isHelpersConfigured };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import isHelpersConfigured from './helpers';
 import { web3, provider } from './setup-provider';
-import { accounts, defaultSender } from './accounts';
+import { accounts, accountsConfig, defaultSender } from './accounts';
 import contract from './setup-loader';
 
-export { accounts, defaultSender, web3, provider, contract, isHelpersConfigured };
+export { accounts, accountsConfig, defaultSender, web3, provider, contract, isHelpersConfigured };


### PR DESCRIPTION
I'm using the exposed web3.js instance to send manually signed transactions and running into the issue that I can't access the generated private keys. I believe this is within the scope of this package.

I initially just re-exported the `accountsConfig` exported by `src/accounts.ts`, but it might be better to instead merge `accounts` and `accountsConfig` into one object and export the combination.

N.B.: The initial commit is still exporting the "hidden" default sender.