### PR TITLE
Change recommended mocha usage

### DIFF
--- a/docs/modules/ROOT/pages/choosing-a-test-runner.adoc
+++ b/docs/modules/ROOT/pages/choosing-a-test-runner.adoc
@@ -63,7 +63,7 @@ $ npm install --save-dev mocha chai
 All tests in the `test` directory are then executed with:
 
 ```bash
-$ npx mocha --recursive test --exit
+$ npx mocha --recursive --exit
 ```
 
 WARNING: Mocha's `--exit` flag is required when using Truffle contracts. Otherwise, the test suite will not exit. https://github.com/trufflesuite/truffle/issues/2560[Learn more].

--- a/docs/modules/ROOT/pages/getting-started.adoc
+++ b/docs/modules/ROOT/pages/getting-started.adoc
@@ -111,7 +111,7 @@ This is what that looks like when using Mocha:
 // package.json
 
 "scripts": {
-  "test": "mocha --exit --recursive test"
+  "test": "mocha --exit --recursive"
 }
 ```
 
@@ -155,7 +155,7 @@ You can set your project to recompile all contracts when running tests by adding
 // package.json
 
 "scripts": {
-  "test": "oz compile && mocha --exit --recursive test"
+  "test": "oz compile && mocha --exit --recursive"
 }
 ```
 ====

--- a/docs/modules/ROOT/pages/migrating-from-truffle.adoc
+++ b/docs/modules/ROOT/pages/migrating-from-truffle.adoc
@@ -26,7 +26,7 @@ Don't forget to make Mocha the entry point of your test suite once you install i
 
  "scripts": {
 -  "test": "npx truffle test"
-+  "test": "npx mocha --exit --recursive test"
++  "test": "npx mocha --exit --recursive"
  }
 ----
 


### PR DESCRIPTION
Our recommended mocha usage explicitly specifies the `test` directory. This is not necessary because it's the default if nothing else is specified. Relying on the default is better because it allows you to run only a few test files by specifing their name on the command line (`npm test test/foo.js`).