### PR TITLE
adds ganache allowUnlimitedContractSize options to config

### DIFF
--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -12,6 +12,7 @@ const defaultConfig = {
 
   blockGasLimit: DEFAULT_BLOCK_GAS_LIMIT,
   gasPrice: 20e9,
+  allowUnlimitedContractSize: false,
 };
 
 describe('config', (): void => {

--- a/src/config.ts
+++ b/src/config.ts
@@ -16,6 +16,7 @@ type Config = {
   gasPrice: number;
   setupProvider: (baseProvider: Provider) => Promise<Provider>;
   coverage: boolean;
+  allowUnlimitedContractSize: boolean;
 };
 
 export const DEFAULT_BLOCK_GAS_LIMIT = 8e6;
@@ -39,6 +40,7 @@ const defaultConfig: Config = {
   setupProvider: async baseProvider => baseProvider,
 
   coverage: false,
+  allowUnlimitedContractSize: false,
 };
 
 function getConfig(): Config {

--- a/src/ganache-server.ts
+++ b/src/ganache-server.ts
@@ -9,11 +9,12 @@ function send(msg: Message): void {
   process.send(msg);
 }
 
-function setupServer({ accountsConfig, gasLimit, gasPrice, coverage }: Options) {
+function setupServer({ accountsConfig, gasLimit, gasPrice, coverage, allowUnlimitedContractSize }: Options) {
   const ganacheOpts = {
     accounts: accountsConfig,
     gasLimit,
     gasPrice: `0x${gasPrice.toString(16)}`,
+    allowUnlimitedContractSize,
   };
 
   if (!coverage) {

--- a/src/setup-ganache.ts
+++ b/src/setup-ganache.ts
@@ -25,6 +25,7 @@ export type Options = {
   gasLimit: number;
   gasPrice: number;
   coverage: boolean;
+  allowUnlimitedContractSize: boolean;
 };
 
 export default async function(): Promise<string> {
@@ -40,6 +41,7 @@ export default async function(): Promise<string> {
     gasLimit: config.blockGasLimit,
     gasPrice: config.gasPrice,
     coverage: config.coverage,
+    allowUnlimitedContractSize: config.allowUnlimitedContractSize,
   };
   server.send(options);
 


### PR DESCRIPTION
I have a particularly big smart contract that I want to test while development and before/while it gets refactored. This option allows me to do so instead of having to mess with ganache directly. I hope this is within the scope of this package.