### PR TITLE
Fix Advanced Options docs titles

### DIFF
--- a/docs/modules/ROOT/pages/getting-started.adoc
+++ b/docs/modules/ROOT/pages/getting-started.adoc
@@ -231,7 +231,7 @@ module.exports = {
 };
 ```
 
-==== `fork` and `unlocked_accounts`
+==== ``fork`` and ``unlocked_accounts``
 
 These options allow Test Environment's local blockchain to _fork_ an existing one instead of starting from an empty state. By using them you can test how your code interacts with live third party protocols (like the MakerDAO system) without having to deploy them yourself!
 


### PR DESCRIPTION
Some of the titles are not rendering correctly: I'm not sure what's causing this, it might be related to the single backtick.

![image](https://user-images.githubusercontent.com/2530770/79999823-c5fceb80-8492-11ea-8c2a-84d7dd1cca4b.png)
