### PR TITLE
Fix block limit

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -99,8 +99,8 @@ function getConfig(): Config {
     //  2. increase how much gas transactions send by default
     //  3. reduce the gas price to prevent the account's funds from being affected by this too much
 
-    config.blockGasLimit = 0xfffffffffffff;
-    config.contracts.defaultGas = config.blockGasLimit * 0.75;
+    config.blockGasLimit = 0xfffffffffff;
+    config.contracts.defaultGas = Math.floor(config.blockGasLimit * 0.75);
     config.contracts.defaultGasPrice = 1;
     config.gasPrice = 1;
   }

--- a/src/config.ts
+++ b/src/config.ts
@@ -99,8 +99,8 @@ function getConfig(): Config {
     //  2. increase how much gas transactions send by default
     //  3. reduce the gas price to prevent the account's funds from being affected by this too much
 
-    config.blockGasLimit = 0xfffffffffff;
-    config.contracts.defaultGas = Math.floor(config.blockGasLimit * 0.75);
+    config.node.gasLimit = 0xfffffffffff;
+    config.contracts.defaultGas = Math.floor(config.node.gasLimit * 0.75);
     config.contracts.defaultGasPrice = 1;
     config.gasPrice = 1;
   }


### PR DESCRIPTION
Hi! I use `openzeppelin-test-environment` for testing my contracts. Recently I was integrating coverage into my project and stumbled over `Exceeds block gas limit` error.
I used `openzeppelin-contracts` as an example along with it's forked `ganache-core` and `solidity-coverage` packages.

What I found is that the `test-environment` overrides `blockGasLimit` value with a different value than specified in `solidity-coverage` package. The difference is the two `f`s. When I removed these `f`s from this hex value, the error was gone.

Also, I found that the `blockGasLimit` is obsolete and this value moved to `node.gasLimit`.

The solidity-coverage block limit resides here https://github.com/rotcivegaf/solidity-coverage/blob/master/lib/app.js#L16

Not sure how to test it properly.