### PR TITLE
Fix typos in docs

### DIFF
--- a/docs/modules/ROOT/pages/api.adoc
+++ b/docs/modules/ROOT/pages/api.adoc
@@ -1,6 +1,6 @@
 = API Reference
 
-`test-environment` exposes a number of variables that are used to interact with the local testing blockchain it setups. These are described in detail here:
+`test-environment` exposes a number of variables that are used to interact with the local testing blockchain it sets up. These are described in detail here:
 
 [source,javascript]
 ----
@@ -31,13 +31,13 @@ await myToken.transfer(receiver, 100, { from: sender });
 defaultSender: string
 ----
 
-A special account that is used by contracts created via `contract` when no account is specified for a transaction (i.e. there is no explicit `from`). This account is _not_ included in `accounts` to prevent accidental bugs during testing: whenever you want an account to make an action (deploy a contract, transfer ownership, etc.) you should be explicit about the sender of the transaction:
+A special account that is used by contracts created via `contract` when no account is specified for a transaction (i.e. there is no explicit `from`). This account is _not_ included in `accounts` to prevent accidental bugs during testing: whenever you want an account to make an action (deploy a contract, transfer ownership, etc.) you should be explicit about the sender of the transaction:
 
 [source,javascript]
 ----
 const [ owner ] = accounts;
 
-// The depoloyment will be made by 'defaultSender' (not 'owner'!), making it
+// The deployment will be made by 'defaultSender' (not 'owner'!), making it
 // the contract's owner
 const myContract = await Ownable.new();
 
@@ -71,7 +71,7 @@ NOTE: Head over to the xref:contract-loader::index.adoc[documentation for Contra
 
 == web3
 
-A https://www.npmjs.com/package/web3[`web3`] instance, connected to the local testing blockchain. Useful to access utiltiies like `web3.eth.sign`, `web3.eth.getTransaction`, or `web3.utils.sha3`.
+A https://www.npmjs.com/package/web3[`web3`] instance, connected to the local testing blockchain. Useful to access utilities like `web3.eth.sign`, `web3.eth.getTransaction`, or `web3.utils.sha3`.
 
 == provider
 

--- a/docs/modules/ROOT/pages/migrating-from-truffle.adoc
+++ b/docs/modules/ROOT/pages/migrating-from-truffle.adoc
@@ -32,14 +32,14 @@ Don't forget to make Mocha the entry point of your test suite once you install i
 
 WARNING: Mocha's `--exit` flag is required when using Truffle contracts. Otherwise, the test suite will not exit. https://github.com/trufflesuite/truffle/issues/2560[Learn more].
 
-== Switching to Test Envrionment
+== Switching to Test Environment
 
 Some bits of your test files will need to be modified during the migration. The changes are only a few, but important:
 
 1. Add `require('@openzeppelin/test-environment')` and export relevant objects, such as `accounts`, `contract` and `web3`.
 2. Add `require('chai')` and set it up (Truffle does this automagically).
 3. Replace all instances of `artifacts.require` with `contract.fromArtifact`
-4. Replace all intances of Truffle's `contract` function with a regular Mocha `describe`. You can still access the accounts array in `accounts`.
+4. Replace all instances of Truffle's `contract` function with a regular Mocha `describe`. You can still access the accounts array in `accounts`.
 
 That's it! Let's see what a full migration might look like:
 


### PR DESCRIPTION
Fix typos.  Copied pages to Google Docs to do a spell check.

A typo was reported by a community member via Intercom.