### PR TITLE
Add a port number as an optional config value

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -24,6 +24,7 @@ export type Config = {
     allowUnlimitedContractSize?: boolean;
     // {url:port@blocknumber} for example http://localhost:8545@1599200
     fork?: string;
+    port?: number;
     unlocked_accounts?: string[];
   };
 };

--- a/src/ganache-server.ts
+++ b/src/ganache-server.ts
@@ -29,7 +29,7 @@ process.once('message', (options: NodeOptions) => {
   // processes of test-environment may be run in parallel.
   // It also means however that the port (and therefore host URL) is not
   // available until the server finishes initialization.
-  server.listen(undefined, function (err: unknown) {
+  server.listen(options.port, function (err: unknown) {
     if (err) {
       send({ type: 'error' });
     } else {

--- a/src/setup-ganache.ts
+++ b/src/setup-ganache.ts
@@ -27,6 +27,7 @@ export type NodeOptions = {
   gasLimit?: number;
   allowUnlimitedContractSize?: boolean;
   fork?: string;
+  port?: number;
   unlocked_accounts?: string[];
 };
 


### PR DESCRIPTION
This will solve #65 if you specify the same port number in `eth-gas-reporter` and `test-environment` configs. When you ignore a port number value in your config, it will use a default `undefined` just like before.