### PR TITLE
Fix HTML report pointing to instrumented files

### DIFF
--- a/src/coverage.ts
+++ b/src/coverage.ts
@@ -71,6 +71,9 @@ export async function runCoverage(skipFiles: string[], compileCommand: string, t
     // wait for the tests to finish
     await once(forked, 'close');
 
+    // Clean up before writing report
+    cleanUp();
+
     // write a report
     await api.report();
   } catch (e) {


### PR DESCRIPTION
The HTML report generated by the current `runCoverage` will point to instrumented files. `cleanUp` needs to run before `api.report()` so that the correct contract files are used.